### PR TITLE
Add Automated Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Build and Release Iconset
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Build TAK Data Package
+      run: ./scripts/create_TAKDataPackage.sh
+      
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          Iconset-Package.zip
+          GEMA NZEM Symbology Set.zip
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically build and release the iconset packages when version tags are pushed.

### Changes
- Added `.github/workflows/release.yml` workflow
- Triggers on version tags (v*)
- Runs `create_TAKDataPackage.sh` build script
- Attaches both zip files to GitHub releases
- Auto-generates release notes

### Usage
Create and push a version tag to trigger a release:
```bash
git tag v1.0.0
git push origin v1.0.0
