### PR TITLE
Fix Release Workflow File Path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         files: |
           Iconset-Package.zip
-          GEMA NZEM Symbology Set.zip
+          datapackage/iconsets/GEMA NZEM Symbology Set.zip
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the file path in the release workflow to correctly locate the GEMA NZEM Symbology Set.zip file.

### Changes
- Updated file path from root to `datapackage/iconsets/GEMA NZEM Symbology Set.zip`
- Ensures both zip files are properly attached to releases

### Issue
The workflow was failing to find the iconset zip file because it's generated in a subfolder, not the root directory.
