### PR TITLE
Fix Workflow Directory Creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Build TAK Data Package
-      run: ./scripts/create_TAKDataPackage.sh
+      run: |
+        mkdir -p datapackage/iconsets
+        ./scripts/create_TAKDataPackage.sh
       
     - name: Create Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow by ensuring the required directory structure exists before running the build script.

### Changes
- Added `mkdir -p datapackage/iconsets` before build script execution
- Prevents "No such file or directory" error during zip creation

### Issue
The build script was failing because it assumed the `datapackage/iconsets/` directory already existed, but GitHub Actions starts with a clean checkout.

### Result
Both zip files will now be successfully created and attached to releases.
